### PR TITLE
support `pull_request_target` as the event

### DIFF
--- a/.github/workflows/action.yml
+++ b/.github/workflows/action.yml
@@ -1,8 +1,7 @@
 name: Test Action
 
 on:
-  - pull_request
-  - pull_request_review
+  - pull_request_target
 
 jobs:
   run:
@@ -13,5 +12,5 @@ jobs:
       - uses: ./
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
-          allowed-actors: tjenkinson, dependabot-preview[bot], dependabot[bot]
+          allowed-actors: tjenkinson, dependabot[bot]
           package-block-list: '@actions/core, @actions/github'

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ It currently supports npm and yarn.
 - `approve` (optional): Automatically approve the PR if it qualifies for auto merge. _Default: `true`_
 - `package-block-list` (optional): A comma separated list of packages that auto merge should not be allowed for.
 
-You should configure this action to run on the `pull_request` event.
+You should configure this action to run on the `pull_request_target` event. If you use `pull_request` you must provide a custom `repo-token` which has permission to merge. [The default token for dependabot PRs only has read-only access](https://github.blog/changelog/2021-02-19-github-actions-workflows-triggered-by-dependabot-prs-will-run-with-read-only-permissions/).
 
 ## Example Action
 
@@ -24,7 +24,7 @@ You should configure this action to run on the `pull_request` event.
 name: Auto Merge Dependency Updates
 
 on:
-  - pull_request
+  - pull_request_target
 
 jobs:
   run:

--- a/dist/index.js
+++ b/dist/index.js
@@ -10513,7 +10513,7 @@ function run() {
                     core.info('Starting');
                     context = github.context;
                     core.debug(JSON.stringify(context, null, 2));
-                    if (!['pull_request', 'pull_request_review'].includes(github.context.eventName)) {
+                    if (!['pull_request', 'pull_request_target', 'pull_request_review'].includes(github.context.eventName)) {
                         core.error("Unsupported event name: " + github.context.eventName);
                         return [2 /*return*/, Result.UnknownEvent];
                     }

--- a/src/run.test.ts
+++ b/src/run.test.ts
@@ -153,474 +153,478 @@ describe('run', () => {
     expect(await run()).toBe(Result.UnknownEvent);
   });
 
-  ['pull_request', 'pull_request_review'].forEach((name) => {
-    describe(`when the event name is ${name}`, () => {
-      let mockAllowedActors: string;
-      let mockAllowedUpdateTypes: string;
-      let mockApprove: string;
-      let mockPackageBlockList: string;
-
-      beforeEach(() => {
-        github.context.eventName = name;
-        mockAllowedActors = '';
-        mockAllowedUpdateTypes = '';
-        mockApprove = '';
-        mockPackageBlockList = '';
-
-        const getInputMock = when(core.getInput as any).mockImplementation(
-          () => {
-            throw new Error('Unexpected call');
-          }
-        );
-        getInputMock
-          .calledWith('repo-token', { required: true })
-          .mockReturnValue('token');
-        getInputMock
-          .calledWith('allowed-actors', { required: true })
-          .mockImplementation(() => mockAllowedActors);
-        getInputMock
-          .calledWith('allowed-update-types', { required: true })
-          .mockImplementation(() => mockAllowedUpdateTypes);
-        getInputMock
-          .calledWith('approve')
-          .mockImplementation(() => mockApprove);
-        getInputMock
-          .calledWith('package-block-list')
-          .mockImplementation(() => mockPackageBlockList);
-      });
-
-      it('stops if the actor is not in the allow list', async () => {
-        github.context.actor = 'unknown';
-        expect(await run()).toBe(Result.ActorNotAllowed);
-      });
-
-      describe('with an allowed actor', () => {
-        let mockPackageJsonPr: any;
-        let mockPackageJsonBase: any;
-        let mockCommit: any;
-        let mockPr: any;
-        let reviewSubmitted: boolean;
-        let reposGetContentMock: jest.Mock;
-        let validMergeCallMock: jest.Mock;
-        const mockSha = 'mockSha';
+  ['pull_request', 'pull_request_target', 'pull_request_review'].forEach(
+    (name) => {
+      describe(`when the event name is ${name}`, () => {
+        let mockAllowedActors: string;
+        let mockAllowedUpdateTypes: string;
+        let mockApprove: string;
+        let mockPackageBlockList: string;
 
         beforeEach(() => {
-          mockAllowedActors = 'actor1, actor2';
-          mockPackageJsonPr = {};
-          mockPackageJsonBase = {};
-          reviewSubmitted = false;
+          github.context.eventName = name;
+          mockAllowedActors = '';
+          mockAllowedUpdateTypes = '';
+          mockApprove = '';
+          mockPackageBlockList = '';
 
-          github.context.actor = 'actor2';
-          (github.context as any).repo = {
-            owner: 'repoOwner',
-            repo: 'repo ',
-          };
-          (github.context as any).ref = 'ref';
-          (github.context as any).payload = {
-            pull_request: {
-              number: 1,
-              base: {
-                ref: 'baseRef',
-              },
-            },
-          };
-          mockCommit = {
-            data: {
-              files: [
-                { filename: 'package.json', status: 'modified' },
-                { filename: 'package-lock.json', status: 'modified' },
-                { filename: 'yarn.lock', status: 'modified' },
-              ],
-            },
-          };
-          mockPr = {};
-
-          reposGetContentMock = jest.fn();
-          when(reposGetContentMock)
-            .mockImplementation(() => {
+          const getInputMock = when(core.getInput as any).mockImplementation(
+            () => {
               throw new Error('Unexpected call');
-            })
-            .calledWith({
-              owner: github.context.repo.owner,
-              repo: github.context.repo.repo,
-              path: 'package.json',
-              ref: github.context.ref,
-            })
-            .mockImplementation(() =>
-              Promise.resolve({
-                data: {
-                  type: 'file',
-                  encoding: 'base64',
-                  content: Buffer.from(
-                    JSON.stringify(mockPackageJsonPr, null, 2)
-                  ).toString('base64'),
+            }
+          );
+          getInputMock
+            .calledWith('repo-token', { required: true })
+            .mockReturnValue('token');
+          getInputMock
+            .calledWith('allowed-actors', { required: true })
+            .mockImplementation(() => mockAllowedActors);
+          getInputMock
+            .calledWith('allowed-update-types', { required: true })
+            .mockImplementation(() => mockAllowedUpdateTypes);
+          getInputMock
+            .calledWith('approve')
+            .mockImplementation(() => mockApprove);
+          getInputMock
+            .calledWith('package-block-list')
+            .mockImplementation(() => mockPackageBlockList);
+        });
+
+        it('stops if the actor is not in the allow list', async () => {
+          github.context.actor = 'unknown';
+          expect(await run()).toBe(Result.ActorNotAllowed);
+        });
+
+        describe('with an allowed actor', () => {
+          let mockPackageJsonPr: any;
+          let mockPackageJsonBase: any;
+          let mockCommit: any;
+          let mockPr: any;
+          let reviewSubmitted: boolean;
+          let reposGetContentMock: jest.Mock;
+          let validMergeCallMock: jest.Mock;
+          const mockSha = 'mockSha';
+
+          beforeEach(() => {
+            mockAllowedActors = 'actor1, actor2';
+            mockPackageJsonPr = {};
+            mockPackageJsonBase = {};
+            reviewSubmitted = false;
+
+            github.context.actor = 'actor2';
+            (github.context as any).repo = {
+              owner: 'repoOwner',
+              repo: 'repo ',
+            };
+            (github.context as any).ref = 'ref';
+            (github.context as any).payload = {
+              pull_request: {
+                number: 1,
+                base: {
+                  ref: 'baseRef',
                 },
+              },
+            };
+            mockCommit = {
+              data: {
+                files: [
+                  { filename: 'package.json', status: 'modified' },
+                  { filename: 'package-lock.json', status: 'modified' },
+                  { filename: 'yarn.lock', status: 'modified' },
+                ],
+              },
+            };
+            mockPr = {};
+
+            reposGetContentMock = jest.fn();
+            when(reposGetContentMock)
+              .mockImplementation(() => {
+                throw new Error('Unexpected call');
               })
-            )
-            .calledWith({
-              owner: github.context.repo.owner,
-              repo: github.context.repo.repo,
-              path: 'package.json',
-              ref: (github.context.payload.pull_request as any).base.ref,
-            })
-            .mockImplementation(() =>
-              Promise.resolve({
-                data: {
-                  type: 'file',
-                  encoding: 'base64',
-                  content: Buffer.from(
-                    JSON.stringify(mockPackageJsonBase, null, 2)
-                  ).toString('base64'),
-                },
+              .calledWith({
+                owner: github.context.repo.owner,
+                repo: github.context.repo.repo,
+                path: 'package.json',
+                ref: github.context.ref,
               })
+              .mockImplementation(() =>
+                Promise.resolve({
+                  data: {
+                    type: 'file',
+                    encoding: 'base64',
+                    content: Buffer.from(
+                      JSON.stringify(mockPackageJsonPr, null, 2)
+                    ).toString('base64'),
+                  },
+                })
+              )
+              .calledWith({
+                owner: github.context.repo.owner,
+                repo: github.context.repo.repo,
+                path: 'package.json',
+                ref: (github.context.payload.pull_request as any).base.ref,
+              })
+              .mockImplementation(() =>
+                Promise.resolve({
+                  data: {
+                    type: 'file',
+                    encoding: 'base64',
+                    content: Buffer.from(
+                      JSON.stringify(mockPackageJsonBase, null, 2)
+                    ).toString('base64'),
+                  },
+                })
+              );
+
+            const reposGetCommitMock = jest.fn();
+            when(reposGetCommitMock)
+              .expectCalledWith({
+                owner: github.context.repo.owner,
+                repo: github.context.repo.repo,
+                ref: github.context.ref,
+              })
+              .mockImplementation(() => mockCommit);
+
+            const pullsGetMock = jest.fn();
+            when(pullsGetMock)
+              .expectCalledWith({
+                owner: github.context.repo.owner,
+                repo: github.context.repo.repo,
+                pull_number: github.context.payload.pull_request!.number,
+              })
+              .mockImplementation(() => mockPr);
+
+            const mockReviewId = 'mockReviewId';
+            const createReviewMock = jest.fn();
+            when(createReviewMock)
+              .expectCalledWith({
+                owner: github.context.repo.owner,
+                repo: github.context.repo.repo,
+                pull_number: github.context.payload.pull_request!.number,
+              })
+              .mockReturnValue(Promise.resolve({ data: { id: mockReviewId } }));
+
+            const submitReviewMock = jest.fn();
+            when(submitReviewMock)
+              .expectCalledWith({
+                owner: github.context.repo.owner,
+                repo: github.context.repo.repo,
+                pull_number: github.context.payload.pull_request!.number,
+                review_id: mockReviewId,
+                event: 'APPROVE',
+              })
+              .mockImplementation(() => {
+                reviewSubmitted = true;
+                return Promise.resolve();
+              });
+
+            const mergeMock = jest.fn();
+            validMergeCallMock = jest.fn();
+            when(mergeMock)
+              .expectCalledWith({
+                owner: github.context.repo.owner,
+                repo: github.context.repo.repo,
+                pull_number: github.context.payload.pull_request!.number,
+                sha: mockSha,
+              })
+              .mockImplementation(validMergeCallMock);
+
+            const octokitMock = {
+              repos: {
+                getContent: reposGetContentMock,
+                getCommit: reposGetCommitMock,
+              },
+              pulls: {
+                get: pullsGetMock,
+                createReview: createReviewMock,
+                submitReview: submitReviewMock,
+                merge: mergeMock,
+              },
+            };
+
+            const getOctokitOptionsReturn = Symbol('getOctokitOptionsReturn');
+            when((githubUtils as any).getOctokitOptions)
+              .expectCalledWith('token', {
+                throttle: expect.objectContaining({
+                  onRateLimit: expect.any(Function),
+                  onAbuseLimit: expect.any(Function),
+                }),
+              })
+              .mockReturnValue(getOctokitOptionsReturn);
+
+            const octokitMockBuilder = jest.fn();
+            when(octokitMockBuilder)
+              .expectCalledWith(getOctokitOptionsReturn)
+              .mockReturnValue(octokitMock);
+
+            when((githubUtils.GitHub as any).plugin)
+              .expectCalledWith(throttling)
+              .mockReturnValue(octokitMockBuilder);
+          });
+
+          it('errors if allowed-update-types invalid', async () => {
+            mockAllowedUpdateTypes = 'invalid';
+            await expect(run()).rejects.toHaveProperty(
+              'message',
+              'allowed-update-types invalid'
             );
+          });
 
-          const reposGetCommitMock = jest.fn();
-          when(reposGetCommitMock)
-            .expectCalledWith({
-              owner: github.context.repo.owner,
-              repo: github.context.repo.repo,
-              ref: github.context.ref,
-            })
-            .mockImplementation(() => mockCommit);
+          it('errors if the content type is incorrect', async () => {
+            reposGetContentMock.mockReturnValue(
+              Promise.resolve({ data: { type: 'unknown' } })
+            );
+            await expect(run()).rejects.toHaveProperty(
+              'message',
+              'Unexpected repo content response'
+            );
+          });
 
-          const pullsGetMock = jest.fn();
-          when(pullsGetMock)
-            .expectCalledWith({
-              owner: github.context.repo.owner,
-              repo: github.context.repo.repo,
-              pull_number: github.context.payload.pull_request!.number,
-            })
-            .mockImplementation(() => mockPr);
+          it('errors if the content encoding is incorrect', async () => {
+            reposGetContentMock.mockReturnValue(
+              Promise.resolve({ data: { type: 'file', encoding: 'unknown' } })
+            );
+            await expect(run()).rejects.toHaveProperty(
+              'message',
+              'Unexpected repo content response'
+            );
+          });
 
-          const mockReviewId = 'mockReviewId';
-          const createReviewMock = jest.fn();
-          when(createReviewMock)
-            .expectCalledWith({
-              owner: github.context.repo.owner,
-              repo: github.context.repo.repo,
-              pull_number: github.context.payload.pull_request!.number,
-            })
-            .mockReturnValue(Promise.resolve({ data: { id: mockReviewId } }));
+          it('stops if more than the allowed files change', async () => {
+            mockCommit.data.files = [
+              { filename: 'something', status: 'modified' },
+            ];
+            expect(await run()).toBe(Result.FileNotAllowed);
 
-          const submitReviewMock = jest.fn();
-          when(submitReviewMock)
-            .expectCalledWith({
-              owner: github.context.repo.owner,
-              repo: github.context.repo.repo,
-              pull_number: github.context.payload.pull_request!.number,
-              review_id: mockReviewId,
-              event: 'APPROVE',
-            })
-            .mockImplementation(() => {
-              reviewSubmitted = true;
-              return Promise.resolve();
-            });
+            mockCommit.data.files = [
+              { filename: 'package.json', status: 'modified' },
+              { filename: 'something', status: 'modified' },
+            ];
+            expect(await run()).toBe(Result.FileNotAllowed);
+          });
 
-          const mergeMock = jest.fn();
-          validMergeCallMock = jest.fn();
-          when(mergeMock)
-            .expectCalledWith({
-              owner: github.context.repo.owner,
-              repo: github.context.repo.repo,
-              pull_number: github.context.payload.pull_request!.number,
-              sha: mockSha,
-            })
-            .mockImplementation(validMergeCallMock);
+          it('stops if an allowed file is changed but not modified', async () => {
+            mockCommit.data.files = [
+              { filename: 'package.json', status: 'something' },
+            ];
+            expect(await run()).toBe(Result.FileNotAllowed);
+          });
 
-          const octokitMock = {
-            repos: {
-              getContent: reposGetContentMock,
-              getCommit: reposGetCommitMock,
-            },
-            pulls: {
-              get: pullsGetMock,
-              createReview: createReviewMock,
-              submitReview: submitReviewMock,
-              merge: mergeMock,
-            },
-          };
+          it('stops if the diff of the package.json contains additions', async () => {
+            mockPackageJsonPr = { addition: true };
+            expect(await run()).toBe(Result.UnexpectedChanges);
+          });
 
-          const getOctokitOptionsReturn = Symbol('getOctokitOptionsReturn');
-          when((githubUtils as any).getOctokitOptions)
-            .expectCalledWith('token', {
-              throttle: expect.objectContaining({
-                onRateLimit: expect.any(Function),
-                onAbuseLimit: expect.any(Function),
-              }),
-            })
-            .mockReturnValue(getOctokitOptionsReturn);
+          it('stops if the diff of the package.json contains removals', async () => {
+            mockPackageJsonBase = { addition: true };
+            expect(await run()).toBe(Result.UnexpectedChanges);
+          });
 
-          const octokitMockBuilder = jest.fn();
-          when(octokitMockBuilder)
-            .expectCalledWith(getOctokitOptionsReturn)
-            .mockReturnValue(octokitMock);
+          it('stops if the diff of the package.json contains changes to something other than dependencies or devDependencies', async () => {
+            mockPackageJsonBase.name = 'something';
+            mockPackageJsonPr.name = 'somethingElse';
+            expect(await run()).toBe(Result.UnexpectedPropertyChange);
+          });
 
-          when((githubUtils.GitHub as any).plugin)
-            .expectCalledWith(throttling)
-            .mockReturnValue(octokitMockBuilder);
-        });
+          it('stops if one of the updates is in the package block list', async () => {
+            mockAllowedUpdateTypes = 'dependencies: patch';
+            mockPackageBlockList = 'dep1, dep2';
 
-        it('errors if allowed-update-types invalid', async () => {
-          mockAllowedUpdateTypes = 'invalid';
-          await expect(run()).rejects.toHaveProperty(
-            'message',
-            'allowed-update-types invalid'
-          );
-        });
+            mockPackageJsonBase.dependencies = {
+              dep1: '1.2.3',
+            };
+            mockPackageJsonPr.dependencies = {
+              dep1: '1.2.4',
+            };
+            expect(await run()).toBe(Result.VersionChangeNotAllowed);
 
-        it('errors if the content type is incorrect', async () => {
-          reposGetContentMock.mockReturnValue(
-            Promise.resolve({ data: { type: 'unknown' } })
-          );
-          await expect(run()).rejects.toHaveProperty(
-            'message',
-            'Unexpected repo content response'
-          );
-        });
+            mockPackageJsonBase.dependencies = {
+              dep1: '1.2.3',
+              dep2: '1.2.3',
+            };
+            mockPackageJsonPr.dependencies = {
+              dep1: '1.2.4',
+              dep2: '1.2.4',
+            };
+            expect(await run()).toBe(Result.VersionChangeNotAllowed);
 
-        it('errors if the content encoding is incorrect', async () => {
-          reposGetContentMock.mockReturnValue(
-            Promise.resolve({ data: { type: 'file', encoding: 'unknown' } })
-          );
-          await expect(run()).rejects.toHaveProperty(
-            'message',
-            'Unexpected repo content response'
-          );
-        });
+            mockPackageJsonBase.dependencies = {
+              dep1: '1.2.3',
+              something: '1.2.3',
+            };
+            mockPackageJsonPr.dependencies = {
+              dep1: '1.2.4',
+              something: '1.2.4',
+            };
+            expect(await run()).toBe(Result.VersionChangeNotAllowed);
+          });
 
-        it('stops if more than the allowed files change', async () => {
-          mockCommit.data.files = [
-            { filename: 'something', status: 'modified' },
-          ];
-          expect(await run()).toBe(Result.FileNotAllowed);
+          versionChanges.forEach(({ before, after, minRequired }) => {
+            describe(`with an update from ${JSON.stringify(
+              before
+            )} to "${JSON.stringify(after)}"`, () => {
+              beforeEach(() => {
+                if (before.dev) {
+                  mockPackageJsonBase.devDependencies = before.dev;
+                }
+                if (before.prod) {
+                  mockPackageJsonBase.dependencies = before.prod;
+                }
+                if (after.dev) {
+                  mockPackageJsonPr.devDependencies = after.dev;
+                }
+                if (after.prod) {
+                  mockPackageJsonPr.dependencies = after.prod;
+                }
+              });
 
-          mockCommit.data.files = [
-            { filename: 'package.json', status: 'modified' },
-            { filename: 'something', status: 'modified' },
-          ];
-          expect(await run()).toBe(Result.FileNotAllowed);
-        });
-
-        it('stops if an allowed file is changed but not modified', async () => {
-          mockCommit.data.files = [
-            { filename: 'package.json', status: 'something' },
-          ];
-          expect(await run()).toBe(Result.FileNotAllowed);
-        });
-
-        it('stops if the diff of the package.json contains additions', async () => {
-          mockPackageJsonPr = { addition: true };
-          expect(await run()).toBe(Result.UnexpectedChanges);
-        });
-
-        it('stops if the diff of the package.json contains removals', async () => {
-          mockPackageJsonBase = { addition: true };
-          expect(await run()).toBe(Result.UnexpectedChanges);
-        });
-
-        it('stops if the diff of the package.json contains changes to something other than dependencies or devDependencies', async () => {
-          mockPackageJsonBase.name = 'something';
-          mockPackageJsonPr.name = 'somethingElse';
-          expect(await run()).toBe(Result.UnexpectedPropertyChange);
-        });
-
-        it('stops if one of the updates is in the package block list', async () => {
-          mockAllowedUpdateTypes = 'dependencies: patch';
-          mockPackageBlockList = 'dep1, dep2';
-
-          mockPackageJsonBase.dependencies = {
-            dep1: '1.2.3',
-          };
-          mockPackageJsonPr.dependencies = {
-            dep1: '1.2.4',
-          };
-          expect(await run()).toBe(Result.VersionChangeNotAllowed);
-
-          mockPackageJsonBase.dependencies = {
-            dep1: '1.2.3',
-            dep2: '1.2.3',
-          };
-          mockPackageJsonPr.dependencies = {
-            dep1: '1.2.4',
-            dep2: '1.2.4',
-          };
-          expect(await run()).toBe(Result.VersionChangeNotAllowed);
-
-          mockPackageJsonBase.dependencies = {
-            dep1: '1.2.3',
-            something: '1.2.3',
-          };
-          mockPackageJsonPr.dependencies = {
-            dep1: '1.2.4',
-            something: '1.2.4',
-          };
-          expect(await run()).toBe(Result.VersionChangeNotAllowed);
-        });
-
-        versionChanges.forEach(({ before, after, minRequired }) => {
-          describe(`with an update from ${JSON.stringify(
-            before
-          )} to "${JSON.stringify(after)}"`, () => {
-            beforeEach(() => {
-              if (before.dev) {
-                mockPackageJsonBase.devDependencies = before.dev;
-              }
-              if (before.prod) {
-                mockPackageJsonBase.dependencies = before.prod;
-              }
-              if (after.dev) {
-                mockPackageJsonPr.devDependencies = after.dev;
-              }
-              if (after.prod) {
-                mockPackageJsonPr.dependencies = after.prod;
-              }
-            });
-
-            allowedUpdateTypeCombinations.forEach(
-              ({ allowedUpdateTypes, maxBump }) => {
-                describe(`with allowedUpdateTypes of "${allowedUpdateTypes}"`, () => {
-                  beforeEach(() => {
-                    mockAllowedUpdateTypes = allowedUpdateTypes;
-                  });
-
-                  if (
-                    bumpTypes.indexOf(maxBump.dev) <
-                      bumpTypes.indexOf(minRequired.dev) ||
-                    bumpTypes.indexOf(maxBump.prod) <
-                      bumpTypes.indexOf(minRequired.prod)
-                  ) {
-                    it('stops', async () => {
-                      expect(await run()).toBe(Result.VersionChangeNotAllowed);
+              allowedUpdateTypeCombinations.forEach(
+                ({ allowedUpdateTypes, maxBump }) => {
+                  describe(`with allowedUpdateTypes of "${allowedUpdateTypes}"`, () => {
+                    beforeEach(() => {
+                      mockAllowedUpdateTypes = allowedUpdateTypes;
                     });
-                  } else {
-                    [true, false].forEach((approve) => {
-                      describe(`when approve option is ${
-                        approve ? 'enabled' : 'disabled'
-                      }`, () => {
-                        beforeEach(() => {
-                          mockPr.data = {
-                            state: 'open',
-                            mergeable: true,
-                            head: { sha: mockSha },
-                          };
-                        });
 
-                        if (approve) {
-                          it('approves the PR', async () => {
-                            mockApprove = 'true';
+                    if (
+                      bumpTypes.indexOf(maxBump.dev) <
+                        bumpTypes.indexOf(minRequired.dev) ||
+                      bumpTypes.indexOf(maxBump.prod) <
+                        bumpTypes.indexOf(minRequired.prod)
+                    ) {
+                      it('stops', async () => {
+                        expect(await run()).toBe(
+                          Result.VersionChangeNotAllowed
+                        );
+                      });
+                    } else {
+                      [true, false].forEach((approve) => {
+                        describe(`when approve option is ${
+                          approve ? 'enabled' : 'disabled'
+                        }`, () => {
+                          beforeEach(() => {
+                            mockPr.data = {
+                              state: 'open',
+                              mergeable: true,
+                              head: { sha: mockSha },
+                            };
+                          });
+
+                          if (approve) {
+                            it('approves the PR', async () => {
+                              mockApprove = 'true';
+                              expect(await run()).toBe(Result.Success);
+                            });
+                          } else {
+                            it('does not approve the PR', async () => {
+                              expect(await run()).toBe(Result.Success);
+                              expect(reviewSubmitted).toBe(false);
+                            });
+                          }
+
+                          it('merges the PR', async () => {
                             expect(await run()).toBe(Result.Success);
                           });
-                        } else {
-                          it('does not approve the PR', async () => {
-                            expect(await run()).toBe(Result.Success);
-                            expect(reviewSubmitted).toBe(false);
-                          });
-                        }
 
-                        it('merges the PR', async () => {
-                          expect(await run()).toBe(Result.Success);
-                        });
-
-                        it('aborts if the PR is not open', async () => {
-                          mockPr.data.state = 'unknown';
-                          expect(await run()).toBe(Result.PRNotOpen);
-                        });
-
-                        it('waits 1 second if the PR is not mergeable then retries', async () => {
-                          let resolved = false;
-                          let error: any;
-
-                          mockPr.data.mergeable = false;
-                          const result = run();
-                          result
-                            .then(() => (resolved = true))
-                            .catch((e) => (error = e));
-                          await whenAllPromisesFinished();
-                          expect(error).toBeUndefined();
-                          expect(resolved).toBe(false);
-
-                          mockPr.data.mergeable = true;
-                          jest.advanceTimersByTime(999);
-                          await whenAllPromisesFinished();
-                          expect(resolved).toBe(false);
-
-                          jest.advanceTimersByTime(1);
-                          await whenAllPromisesFinished();
-                          expect(resolved).toBe(true);
-
-                          expect(await result).toBe(Result.Success);
-                        });
-
-                        it('waits 1 second if the PR fails to merge and then retries', async () => {
-                          let resolved = false;
-                          let error: any;
-
-                          validMergeCallMock.mockImplementationOnce(() => {
-                            throw new Error('Oops');
+                          it('aborts if the PR is not open', async () => {
+                            mockPr.data.state = 'unknown';
+                            expect(await run()).toBe(Result.PRNotOpen);
                           });
 
-                          const result = run();
-                          result
-                            .then(() => (resolved = true))
-                            .catch((e) => (error = e));
-                          await whenAllPromisesFinished();
-                          expect(error).toBeUndefined();
-                          expect(resolved).toBe(false);
+                          it('waits 1 second if the PR is not mergeable then retries', async () => {
+                            let resolved = false;
+                            let error: any;
 
-                          jest.advanceTimersByTime(999);
-                          await whenAllPromisesFinished();
-                          expect(resolved).toBe(false);
+                            mockPr.data.mergeable = false;
+                            const result = run();
+                            result
+                              .then(() => (resolved = true))
+                              .catch((e) => (error = e));
+                            await whenAllPromisesFinished();
+                            expect(error).toBeUndefined();
+                            expect(resolved).toBe(false);
 
-                          jest.advanceTimersByTime(1);
-                          await whenAllPromisesFinished();
-                          expect(resolved).toBe(true);
+                            mockPr.data.mergeable = true;
+                            jest.advanceTimersByTime(999);
+                            await whenAllPromisesFinished();
+                            expect(resolved).toBe(false);
 
-                          expect(await result).toBe(Result.Success);
-                        });
+                            jest.advanceTimersByTime(1);
+                            await whenAllPromisesFinished();
+                            expect(resolved).toBe(true);
 
-                        it('stops if the merge fails because the head changed', async () => {
-                          validMergeCallMock.mockImplementation(() => {
-                            throw { status: 409 };
+                            expect(await result).toBe(Result.Success);
                           });
 
-                          expect(await run()).toBe(Result.PRHeadChanged);
-                        });
+                          it('waits 1 second if the PR fails to merge and then retries', async () => {
+                            let resolved = false;
+                            let error: any;
 
-                        it('throws when it has retried for 6 hours', async () => {
-                          let rejected = false;
-                          let error: any;
+                            validMergeCallMock.mockImplementationOnce(() => {
+                              throw new Error('Oops');
+                            });
 
-                          mockPr.data.mergeable = false;
-                          const result = run();
-                          result.catch((e) => {
-                            rejected = true;
-                            error = e;
+                            const result = run();
+                            result
+                              .then(() => (resolved = true))
+                              .catch((e) => (error = e));
+                            await whenAllPromisesFinished();
+                            expect(error).toBeUndefined();
+                            expect(resolved).toBe(false);
+
+                            jest.advanceTimersByTime(999);
+                            await whenAllPromisesFinished();
+                            expect(resolved).toBe(false);
+
+                            jest.advanceTimersByTime(1);
+                            await whenAllPromisesFinished();
+                            expect(resolved).toBe(true);
+
+                            expect(await result).toBe(Result.Success);
                           });
-                          await whenAllPromisesFinished();
-                          expect(error).toBeUndefined();
-                          expect(rejected).toBe(false);
 
-                          jest.runOnlyPendingTimers();
-                          await whenAllPromisesFinished();
-                          expect(rejected).toBe(false);
+                          it('stops if the merge fails because the head changed', async () => {
+                            validMergeCallMock.mockImplementation(() => {
+                              throw { status: 409 };
+                            });
 
-                          jest.setSystemTime(6 * 60 * 60 * 1000);
-                          jest.runOnlyPendingTimers();
-                          await whenAllPromisesFinished();
+                            expect(await run()).toBe(Result.PRHeadChanged);
+                          });
 
-                          expect(rejected).toBe(true);
-                          expect(error?.message).toBe('Timed out');
+                          it('throws when it has retried for 6 hours', async () => {
+                            let rejected = false;
+                            let error: any;
+
+                            mockPr.data.mergeable = false;
+                            const result = run();
+                            result.catch((e) => {
+                              rejected = true;
+                              error = e;
+                            });
+                            await whenAllPromisesFinished();
+                            expect(error).toBeUndefined();
+                            expect(rejected).toBe(false);
+
+                            jest.runOnlyPendingTimers();
+                            await whenAllPromisesFinished();
+                            expect(rejected).toBe(false);
+
+                            jest.setSystemTime(6 * 60 * 60 * 1000);
+                            jest.runOnlyPendingTimers();
+                            await whenAllPromisesFinished();
+
+                            expect(rejected).toBe(true);
+                            expect(error?.message).toBe('Timed out');
+                          });
                         });
                       });
-                    });
-                  }
-                });
-              }
-            );
+                    }
+                  });
+                }
+              );
+            });
           });
         });
       });
-    });
-  });
+    }
+  );
 });

--- a/src/run.ts
+++ b/src/run.ts
@@ -19,7 +19,9 @@ export async function run(): Promise<Result> {
   core.debug(JSON.stringify(context, null, 2));
 
   if (
-    !['pull_request', 'pull_request_review'].includes(github.context.eventName)
+    !['pull_request', 'pull_request_target', 'pull_request_review'].includes(
+      github.context.eventName
+    )
   ) {
     core.error(`Unsupported event name: ${github.context.eventName}`);
     return Result.UnknownEvent;


### PR DESCRIPTION
Given https://github.blog/changelog/2021-02-19-github-actions-workflows-triggered-by-dependabot-prs-will-run-with-read-only-permissions/