### PR TITLE
Add 'merge' option and 'success' output

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,1 +1,2 @@
 /dist
+coverage

--- a/README.md
+++ b/README.md
@@ -18,6 +18,9 @@ It currently supports npm and yarn.
 
 You should configure this action to run on the `pull_request_target` event. If you use `pull_request` you must provide a custom `repo-token` which has permission to merge. [The default token for dependabot PRs only has read-only access](https://github.blog/changelog/2021-02-19-github-actions-workflows-triggered-by-dependabot-prs-will-run-with-read-only-permissions/).
 
+## Outputs
+A `success` output is set to `true` if a commit is eligible for auto merge.
+
 ## Example Action
 
 ```yaml

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ It currently supports npm and yarn.
 You should configure this action to run on the `pull_request_target` event. If you use `pull_request` you must provide a custom `repo-token` which has permission to merge. [The default token for dependabot PRs only has read-only access](https://github.blog/changelog/2021-02-19-github-actions-workflows-triggered-by-dependabot-prs-will-run-with-read-only-permissions/).
 
 ## Outputs
+
 A `success` output is set to `true` if a commit is eligible for auto merge.
 
 ## Example Action

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ It currently supports npm and yarn.
 - `allowed-update-types` (optional): A comma separated list of types of updates that are allowed. Supported: [devDependencies|dependencies]:[major|minor|patch]. _Default: `devDependencies:minor, devDependencies:patch`_
 - `approve` (optional): Automatically approve the PR if it qualifies for auto merge. _Default: `true`_
 - `package-block-list` (optional): A comma separated list of packages that auto merge should not be allowed for.
+- `merge` (optional): Merge the PR if it qualifies. _Default: `true`_
 
 You should configure this action to run on the `pull_request_target` event. If you use `pull_request` you must provide a custom `repo-token` which has permission to merge. [The default token for dependabot PRs only has read-only access](https://github.blog/changelog/2021-02-19-github-actions-workflows-triggered-by-dependabot-prs-will-run-with-read-only-permissions/).
 

--- a/action.yml
+++ b/action.yml
@@ -14,6 +14,9 @@ inputs:
   approve:
     description: 'Automatically approve the PR if it qualifies for auto merge'
     default: 'true'
+  merge:
+    description: 'Merge the PR if it qualifies'
+    default: 'true'
   package-block-list:
     required: false
     description: 'Comma separated list of packages that auto merge should not be allowed for'

--- a/action.yml
+++ b/action.yml
@@ -17,6 +17,9 @@ inputs:
   package-block-list:
     required: false
     description: 'Comma separated list of packages that auto merge should not be allowed for'
+outputs:
+  success:
+    description: '"true" if the commit meets the criteria'
 runs:
   using: 'node12'
   main: 'dist/index.js'

--- a/package-lock.json
+++ b/package-lock.json
@@ -2716,7 +2716,8 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/growly/-/growly-1.3.0.tgz",
       "integrity": "sha1-8QdIy+dq+WS3yWyTxrzCivEgwIE=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "har-schema": {
       "version": "2.0.0",
@@ -3151,6 +3152,7 @@
       "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.2.0.tgz",
       "integrity": "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==",
       "dev": true,
+      "optional": true,
       "requires": {
         "is-docker": "^2.0.0"
       }
@@ -5308,6 +5310,7 @@
       "resolved": "https://registry.npmjs.org/node-notifier/-/node-notifier-8.0.1.tgz",
       "integrity": "sha512-BvEXF+UmsnAfYfoapKM9nGxnP+Wn7P91YfXmrKnfcYCx6VBeoN5Ez5Ogck6I8Bi5k4RlpqRYaw75pAwzX9OphA==",
       "dev": true,
+      "optional": true,
       "requires": {
         "growly": "^1.3.0",
         "is-wsl": "^2.2.0",
@@ -6273,7 +6276,8 @@
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/shellwords/-/shellwords-0.1.1.tgz",
       "integrity": "sha512-vFwSUfQvqybiICwZY5+DAWIPLKsWO31Q91JSKl3UYv+K5c2QRPzn0qzec6QPu1Qc9eHYItiP3NdJqNVqetYAww==",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "signal-exit": {
       "version": "3.0.3",
@@ -6929,7 +6933,8 @@
       "version": "8.3.1",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.1.tgz",
       "integrity": "sha512-FOmRr+FmWEIG8uhZv6C2bTgEVXsHk08kE7mPlrBbEe+c3r9pjceVPgupIfNIhc4yx55H69OXANrUaSuu9eInKg==",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "v8-to-istanbul": {
       "version": "7.0.0",

--- a/src/result.ts
+++ b/src/result.ts
@@ -7,5 +7,6 @@ export enum Result {
   VersionChangeNotAllowed,
   PRNotOpen,
   PRHeadChanged,
-  Success,
+  PRMerged,
+  PRMergeSkipped,
 }

--- a/src/run.test.ts
+++ b/src/run.test.ts
@@ -191,9 +191,7 @@ describe('run', () => {
           getInputMock
             .calledWith('package-block-list')
             .mockImplementation(() => mockPackageBlockList);
-          getInputMock
-            .calledWith('merge')
-            .mockImplementation(() => mockMerge);
+          getInputMock.calledWith('merge').mockImplementation(() => mockMerge);
         });
 
         it('stops if the actor is not in the allow list', async () => {
@@ -305,7 +303,6 @@ describe('run', () => {
                 pull_number: github.context.payload.pull_request!.number,
               })
               .mockImplementation(() => mockListFiles);
-
 
             const mockReviewId = 'mockReviewId';
             const createReviewMock = jest.fn();
@@ -553,20 +550,20 @@ describe('run', () => {
                             beforeEach(() => {
                               mockMerge = 'true';
                             });
-                            
+
                             it('merges the PR', async () => {
                               expect(await run()).toBe(Result.PRMerged);
                             });
-  
+
                             it('aborts if the PR is not open', async () => {
                               mockPr.data.state = 'unknown';
                               expect(await run()).toBe(Result.PRNotOpen);
                             });
-  
+
                             it('waits 1 second if the PR is not mergeable then retries', async () => {
                               let resolved = false;
                               let error: any;
-  
+
                               mockPr.data.mergeable = false;
                               const result = run();
                               result
@@ -575,27 +572,27 @@ describe('run', () => {
                               await whenAllPromisesFinished();
                               expect(error).toBeUndefined();
                               expect(resolved).toBe(false);
-  
+
                               mockPr.data.mergeable = true;
                               jest.advanceTimersByTime(999);
                               await whenAllPromisesFinished();
                               expect(resolved).toBe(false);
-  
+
                               jest.advanceTimersByTime(1);
                               await whenAllPromisesFinished();
                               expect(resolved).toBe(true);
-  
+
                               expect(await result).toBe(Result.PRMerged);
                             });
-  
+
                             it('waits 1 second if the PR fails to merge and then retries', async () => {
                               let resolved = false;
                               let error: any;
-  
+
                               validMergeCallMock.mockImplementationOnce(() => {
                                 throw new Error('Oops');
                               });
-  
+
                               const result = run();
                               result
                                 .then(() => (resolved = true))
@@ -603,30 +600,30 @@ describe('run', () => {
                               await whenAllPromisesFinished();
                               expect(error).toBeUndefined();
                               expect(resolved).toBe(false);
-  
+
                               jest.advanceTimersByTime(999);
                               await whenAllPromisesFinished();
                               expect(resolved).toBe(false);
-  
+
                               jest.advanceTimersByTime(1);
                               await whenAllPromisesFinished();
                               expect(resolved).toBe(true);
-  
+
                               expect(await result).toBe(Result.PRMerged);
                             });
-  
+
                             it('stops if the merge fails because the head changed', async () => {
                               validMergeCallMock.mockImplementation(() => {
                                 throw { status: 409 };
                               });
-  
+
                               expect(await run()).toBe(Result.PRHeadChanged);
                             });
-  
+
                             it('throws when it has retried for 6 hours', async () => {
                               let rejected = false;
                               let error: any;
-  
+
                               mockPr.data.mergeable = false;
                               const result = run();
                               result.catch((e) => {
@@ -636,22 +633,21 @@ describe('run', () => {
                               await whenAllPromisesFinished();
                               expect(error).toBeUndefined();
                               expect(rejected).toBe(false);
-  
+
                               jest.runOnlyPendingTimers();
                               await whenAllPromisesFinished();
                               expect(rejected).toBe(false);
-  
+
                               jest.setSystemTime(6 * 60 * 60 * 1000);
                               jest.runOnlyPendingTimers();
                               await whenAllPromisesFinished();
-  
+
                               expect(rejected).toBe(true);
                               expect(error?.message).toBe('Timed out');
                             });
                           });
                         });
-                          });
-
+                      });
                     }
                   });
                 }

--- a/src/run.test.ts
+++ b/src/run.test.ts
@@ -168,6 +168,7 @@ describe('run', () => {
           mockApprove = '';
           mockPackageBlockList = '';
 
+          (core.setOutput as any).mockReset();
           const getInputMock = when(core.getInput as any).mockImplementation(
             () => {
               throw new Error('Unexpected call');
@@ -234,7 +235,13 @@ describe('run', () => {
                 { filename: 'yarn.lock', status: 'modified' },
               ],
             };
-            mockPr = {};
+            mockPr = {
+              data: {
+                state: 'open',
+                mergeable: true,
+                head: { sha: mockSha },
+              },
+            };
 
             reposGetContentMock = jest.fn();
             when(reposGetContentMock)
@@ -498,19 +505,27 @@ describe('run', () => {
                           Result.VersionChangeNotAllowed
                         );
                       });
+
+                      it('does not set the "success" output', async () => {
+                        await run();
+                        expect(core.setOutput).not.toHaveBeenCalledWith(
+                          'success',
+                          'true'
+                        );
+                      });
                     } else {
+                      it('sets the "success" output', async () => {
+                        await run();
+                        expect(core.setOutput).toHaveBeenCalledWith(
+                          'success',
+                          'true'
+                        );
+                      });
+
                       [true, false].forEach((approve) => {
                         describe(`when approve option is ${
                           approve ? 'enabled' : 'disabled'
                         }`, () => {
-                          beforeEach(() => {
-                            mockPr.data = {
-                              state: 'open',
-                              mergeable: true,
-                              head: { sha: mockSha },
-                            };
-                          });
-
                           if (approve) {
                             it('approves the PR', async () => {
                               mockApprove = 'true';

--- a/src/run.test.ts
+++ b/src/run.test.ts
@@ -203,7 +203,7 @@ describe('run', () => {
           let reviewSubmitted: boolean;
           let reposGetContentMock: jest.Mock;
           let validMergeCallMock: jest.Mock;
-          const mockSha = 'mockSha';
+          const mockSha = 'headSha';
 
           beforeEach(() => {
             mockAllowedActors = 'actor1, actor2';
@@ -223,7 +223,7 @@ describe('run', () => {
                   sha: 'baseSha',
                 },
                 head: {
-                  sha: 'headSha',
+                  sha: mockSha,
                 },
               },
             };

--- a/src/run.ts
+++ b/src/run.ts
@@ -281,6 +281,8 @@ export async function run(): Promise<Result> {
     return Result.VersionChangeNotAllowed;
   }
 
+  core.setOutput('success', 'true');
+
   if (approve) {
     core.info('Approving PR');
     await approvePR();

--- a/src/run.ts
+++ b/src/run.ts
@@ -150,15 +150,15 @@ export async function run(): Promise<Result> {
     throw new Error('Timed out');
   };
 
-  const getCommit = () =>
-    octokit.repos.getCommit({
-      owner: context.repo.owner,
-      repo: context.repo.repo,
-      ref: pr.head.sha,
-    });
-
   const getPR = () =>
     octokit.pulls.get({
+      owner: context.repo.owner,
+      repo: context.repo.repo,
+      pull_number: pr.number,
+    });
+
+  const getPRFiles = () =>
+    octokit.pulls.listFiles({
       owner: context.repo.owner,
       repo: context.repo.repo,
       pull_number: pr.number,
@@ -219,9 +219,10 @@ export async function run(): Promise<Result> {
     return allowed.includes(semver.diff(oldVersionExact, newVersionExact));
   };
 
-  core.info('Getting commit info');
-  const commit = await getCommit();
-  const onlyPackageJsonChanged = commit.data.files.every(
+  core.info('Getting PR files');
+  const prFiles = await getPRFiles();
+  core.debug(JSON.stringify(prFiles, null, 2));
+  const onlyPackageJsonChanged = prFiles.data.every(
     ({ filename, status }) =>
       ['package.json', 'package-lock.json', 'yarn.lock'].includes(filename) &&
       status === 'modified'

--- a/src/run.ts
+++ b/src/run.ts
@@ -109,12 +109,13 @@ export async function run(): Promise<Result> {
   > => {
     for (let i = 0; ; i++) {
       core.info(`Attempt: ${i}`);
-      const prData = await getPR();
-      if (prData.data.state !== 'open') {
+      const livePR = await getPR();
+      core.debug(JSON.stringify(livePR, null, 2));
+      if (livePR.data.state !== 'open') {
         core.error('PR is not open');
         return Result.PRNotOpen;
       }
-      const mergeable = prData.data.mergeable;
+      const mergeable = livePR.data.mergeable;
       if (mergeable) {
         try {
           core.info('Attempting merge');
@@ -122,7 +123,7 @@ export async function run(): Promise<Result> {
             owner: context.repo.owner,
             repo: context.repo.repo,
             pull_number: pr.number,
-            sha: prData.data.head.sha,
+            sha: pr.head.sha,
           });
           core.info('Merged');
           return Result.Success;

--- a/src/run.ts
+++ b/src/run.ts
@@ -169,6 +169,7 @@ export async function run(): Promise<Result> {
       owner: context.repo.owner,
       repo: context.repo.repo,
       pull_number: pr.number,
+      commit_id: pr.head.sha,
     });
     await octokit.pulls.submitReview({
       owner: context.repo.owner,


### PR DESCRIPTION
And fix some bugs. Previously it was checking the changed files in the last commit instead of the PR as a whole, and we were passing the latest sha into the merge command instead of the one the that triggered the action.