### PR TITLE
ci(dependabot): add github actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,5 +1,10 @@
 version: 2
 updates:
+  - package-ecosystem: github-actions
+    directory: '/'
+    schedule:
+      interval: daily
+    open-pull-requests-limit: 99
   - package-ecosystem: npm
     directory: '/'
     schedule:


### PR DESCRIPTION
Hi @tjenkinson, I found this repo through the [GitHub Docs](https://github.com/github/docs) repo, as they use it for [automerging their dependencies](https://github.com/github/docs/blob/main/.github/workflows/automerge-dependencies.yml).

Anyway,  this is a minor chore/house-keeping PR that:

- Enables GitHub Actions to be updated by Dependabot as well
- Adds badges to the readme, to give users some assurance that it doesn't depend on vulnerable dependencies (snyk badge), and passes its tests (CI workflow badge)