### PR TITLE
update allowed files changed error message

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -14984,7 +14984,7 @@ var validBumpTypes = [
 ];
 function run() {
     return __awaiter(this, void 0, void 0, function () {
-        var startTime, context, payload, token, allowedActors, allowedUpdateTypes, approve, packageBlockList, packageAllowListRaw, packageAllowList, merge, mergeMethod, pr, Octokit, octokit, readPackageJson, mergeWhenPossible, getPR, compareCommits, approvePR, validVersionChange, comparison, onlyPackageJsonChanged, packageJsonBase, packageJsonPr, diff, allowedPropsChanges, allowedChange, result;
+        var startTime, context, payload, token, allowedActors, allowedUpdateTypes, approve, packageBlockList, packageAllowListRaw, packageAllowList, merge, mergeMethod, pr, Octokit, octokit, readPackageJson, mergeWhenPossible, getPR, compareCommits, approvePR, validVersionChange, comparison, onlyAllowedFilesChanged, packageJsonBase, packageJsonPr, diff, allowedPropsChanges, allowedChange, result;
         var _this = this;
         return __generator(this, function (_a) {
             switch (_a.label) {
@@ -15224,12 +15224,12 @@ function run() {
                     if (!comparison.data.files) {
                         throw new Error('Unexpected error. `files` missing in commit comparison');
                     }
-                    onlyPackageJsonChanged = comparison.data.files.every(function (_a) {
+                    onlyAllowedFilesChanged = comparison.data.files.every(function (_a) {
                         var filename = _a.filename, status = _a.status;
                         return ['package.json', 'package-lock.json', 'yarn.lock', '.pnp.cjs'].includes(filename) && status === 'modified';
                     });
-                    if (!onlyPackageJsonChanged) {
-                        core.error('More changed than the package.json and lockfile');
+                    if (!onlyAllowedFilesChanged) {
+                        core.error('More changed than the package.json, lockfile, and .pnp.cjs');
                         return [2 /*return*/, Result.FileNotAllowed];
                     }
                     core.info('Retrieving package.json');

--- a/dist/index.js
+++ b/dist/index.js
@@ -14984,7 +14984,7 @@ var validBumpTypes = [
 ];
 function run() {
     return __awaiter(this, void 0, void 0, function () {
-        var startTime, context, payload, token, allowedActors, allowedUpdateTypes, approve, packageBlockList, packageAllowListRaw, packageAllowList, merge, mergeMethod, pr, Octokit, octokit, readPackageJson, mergeWhenPossible, getPR, compareCommits, approvePR, validVersionChange, comparison, onlyAllowedFilesChanged, packageJsonBase, packageJsonPr, diff, allowedPropsChanges, allowedChange, result;
+        var startTime, context, payload, token, allowedActors, allowedUpdateTypes, approve, packageBlockList, packageAllowListRaw, packageAllowList, merge, mergeMethod, pr, Octokit, octokit, readPackageJson, mergeWhenPossible, getPR, compareCommits, approvePR, validVersionChange, comparison, onlyPackageJsonChanged, packageJsonBase, packageJsonPr, diff, allowedPropsChanges, allowedChange, result;
         var _this = this;
         return __generator(this, function (_a) {
             switch (_a.label) {
@@ -15224,12 +15224,12 @@ function run() {
                     if (!comparison.data.files) {
                         throw new Error('Unexpected error. `files` missing in commit comparison');
                     }
-                    onlyAllowedFilesChanged = comparison.data.files.every(function (_a) {
+                    onlyPackageJsonChanged = comparison.data.files.every(function (_a) {
                         var filename = _a.filename, status = _a.status;
                         return ['package.json', 'package-lock.json', 'yarn.lock', '.pnp.cjs'].includes(filename) && status === 'modified';
                     });
-                    if (!onlyAllowedFilesChanged) {
-                        core.error('More changed than the package.json, lockfile, and .pnp.cjs');
+                    if (!onlyPackageJsonChanged) {
+                        core.error('More changed than the package.json and lockfile');
                         return [2 /*return*/, Result.FileNotAllowed];
                     }
                     core.info('Retrieving package.json');

--- a/src/run.ts
+++ b/src/run.ts
@@ -31,6 +31,12 @@ const validBumpTypes = [
   'prepatch',
   'prerelease',
 ];
+const allowedFileChanges = [
+  'package.json',
+  'package-lock.json',
+  'yarn.lock',
+  '.pnp.cjs',
+];
 
 export async function run(): Promise<Result> {
   const startTime = Date.now();
@@ -258,12 +264,12 @@ export async function run(): Promise<Result> {
   }
   const onlyAllowedFilesChanged = comparison.data.files.every(
     ({ filename, status }) =>
-      ['package.json', 'package-lock.json', 'yarn.lock', '.pnp.cjs'].includes(
-        filename
-      ) && status === 'modified'
+      allowedFileChanges.includes(filename) && status === 'modified'
   );
   if (!onlyAllowedFilesChanged) {
-    core.error('More changed than the package.json, lockfile, and .pnp.cjs');
+    core.error(
+      `More changed than ${allowedFileChanges.map((a) => `"${a}"`).join(', ')}`
+    );
     return Result.FileNotAllowed;
   }
 

--- a/src/run.ts
+++ b/src/run.ts
@@ -256,14 +256,14 @@ export async function run(): Promise<Result> {
   if (!comparison.data.files) {
     throw new Error('Unexpected error. `files` missing in commit comparison');
   }
-  const onlyPackageJsonChanged = comparison.data.files.every(
+  const onlyAllowedFilesChanged = comparison.data.files.every(
     ({ filename, status }) =>
       ['package.json', 'package-lock.json', 'yarn.lock', '.pnp.cjs'].includes(
         filename
       ) && status === 'modified'
   );
-  if (!onlyPackageJsonChanged) {
-    core.error('More changed than the package.json and lockfile');
+  if (!onlyAllowedFilesChanged) {
+    core.error('More changed than the package.json, lockfile, and .pnp.cjs');
     return Result.FileNotAllowed;
   }
 


### PR DESCRIPTION
I found allowed files changed error message wasn't updated before, so I simply changed the error message and variable name `onlyPackageJsonChanged` to `onlyAllowedFilesChanged` for consistency. 

and I have no idea why the build file has that much change. If I did something wrong, please let me know. Thanks:)